### PR TITLE
Fixes Issue #5, included new wiringPiDev library into rebar.config

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,1 +1,1 @@
-{port_env, [{"LDFLAGS", "$LDFLAGS -lwiringPi -lpthread"}]}.
+{port_env, [{"LDFLAGS", "$LDFLAGS -lwiringPi -lwiringPiDev -lpthread"}]}.


### PR DESCRIPTION
Seems like a file change in the wiringPi project created a missing dependency for the LCD-related parts of WPI.

As per Issue #5, including the new library in the rebar.config file and recompiling solves the execution exception.
