### PR TITLE
Automatically downloads/installs wiringPi library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 priv/
 ebin/
 *.o
+deps/
+rebar
+*~

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+.DEFAULT_GOAL	:= all
+
+.PHONY:	deps
+
+REBAR=./rebar
+
+all:	deps compile
+
+deps:	rebar
+	@$(REBAR) get-deps
+
+compile:	deps rebar
+	@$(REBAR) compile
+
+clean:	rebar
+	@$(REBAR) clean
+
+distclean:	rebar clean
+	@$(REBAR) delete-deps
+	rm -rf rebar-git
+	rm rebar
+
+uninstall:
+	bash -c "cd deps/wiringPi; sudo ./build uninstall"
+
+rebar:	
+	mkdir -p deps
+	git clone https://github.com/rebar/rebar.git deps/rebar
+	bash -c "cd deps/rebar; ./bootstrap"
+	cp deps/rebar/rebar .
+

--- a/rebar.config
+++ b/rebar.config
@@ -1,1 +1,12 @@
 {port_env, [{"LDFLAGS", "$LDFLAGS -lwiringPi -lwiringPiDev -lpthread"}]}.
+
+{deps, [
+        {wiringPi, ".*", {git, "git://git.drogon.net/wiringPi", {branch, "master"}}, [raw]}
+	]}.
+
+
+{deps_dir, "deps"}.
+{pre_hooks, [
+	     {compile, "bash -c 'cd deps/wiringPi; sudo ./build; sudo ldconfig'"}
+	    ]}.
+	     


### PR DESCRIPTION
Hello again!

I have changed the rebar.config file to automatically download and install the required wiringPi library, and created a Makefile that will do that and make rebar itself, just to make it easier to use, given that rebar's error when a dependency is not found is somewhat cryptic.

Please review if it interests you to merge that into your code.

Thanks for the great work on this library! And I hope I can contribute a bit.

Marco
